### PR TITLE
数字の途中を日付と誤認識する問題を修正

### DIFF
--- a/ja_timex/timex.py
+++ b/ja_timex/timex.py
@@ -67,7 +67,7 @@ class TimexParser:
                 # 文字列中からのパターン検知
                 re_iter = re.finditer(pattern.re_pattern, processed_text)
                 for re_match in re_iter:
-                    if is_parial_pattern_of_number_expression(re_match, processed_text):
+                    if is_parial_pattern_of_number_expression(re_match.span(), processed_text):
                         continue
                     all_extracts.append({"type_name": type_name, "re_match": re_match, "pattern": pattern})
         return all_extracts

--- a/ja_timex/util.py
+++ b/ja_timex/util.py
@@ -1,11 +1,11 @@
 import re
-from typing import Union
+from typing import Tuple, Union
 
 import pendulum
 from pendulum.tz.timezone import Timezone
 
 
-def is_parial_pattern_of_number_expression(re_match: re.Match, processed_text: str) -> bool:
+def is_parial_pattern_of_number_expression(span: Tuple[int, int], processed_text: str) -> bool:
     """対象パターンが数字表現の一部かを判定する
 
     正規表現の記法によっては、数字表現の一部を取得してしまう例がある。
@@ -21,9 +21,17 @@ def is_parial_pattern_of_number_expression(re_match: re.Match, processed_text: s
     Returns:
         bool: 数字表現の一部かを表す真偽値
     """
-    start_i = re_match.span()[0]
+    start_i = span[0]
+    end_i = span[1]
 
-    if start_i != 0 and re.match("[0-9]", processed_text[start_i - 1]):
+    target_text = processed_text[start_i:end_i]
+    # 対象としている文字列が、数字と記号の表現ではなかった場合
+    if not re.fullmatch(r"[0-9\.\-\.,/・]+", target_text):
+        return False
+
+    if start_i != 0 and re.match(r"[0-9\+]", processed_text[start_i - 1]):
+        return True
+    elif end_i != len(processed_text) and re.match(r"[0-9\+]", processed_text[end_i]):
         return True
     else:
         return False

--- a/tests/test_timex_not_applicable.py
+++ b/tests/test_timex_not_applicable.py
@@ -21,14 +21,21 @@ def test_phrase_contains_temporal_expression(p):
     assert p.parse("準備が不十分だった") == []
 
 
-# 取得すべきではないが、ルールベースでは取得せざるを得ないケース
 def test_abstime_partial_pattern_of_number_expression(p):
-    # 部分的な表現はなるべく取得しない
+    # 部分的な表現は取得しない
+    assert len(p.parse("13/13は1です")) == 0
 
-    timexes = p.parse("13/13は1です")
-    assert len(timexes) == 1
-    # 3/13を取得しないが、13/1は取得されてしまう
-    # 「今月8日」といった直後に続く数字があるため
+    # 7.7を取得しない
+    assert len(p.parse("興行収入2億7.765万円を記録した")) == 0
+
+    # 1/5を取得しない
+    assert len(p.parse("1/50の縮小模型")) == 0
+
+    # 320/5を取得しない
+    assert len(p.parse("BCI-321+320/5MP")) == 0
+
+    # 37-3, 3.9を取得しない
+    assert len(p.parse("Core i7-3770（3.90GHz）")) == 0
 
 
 def test_ignore_kansuji():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,24 @@
+from ja_timex.util import is_parial_pattern_of_number_expression
+
+
+def test_is_parial_pattern_of_number_expression():
+    # 前後に数字または+がある場合
+    # マイナスは1/12-1/20といった表現があるため、対象外
+    assert "13/13"[0:4] == "13/1"
+    assert is_parial_pattern_of_number_expression((0, 4), "13/13")
+
+    assert "13/13"[1:5] == "3/13"
+    assert is_parial_pattern_of_number_expression((1, 5), "13/13")
+
+    assert "13/1+2"[0:4] == "13/1"
+    assert is_parial_pattern_of_number_expression((0, 4), "13/1+2")
+
+    assert "+3/13"[1:5] == "3/13"
+    assert is_parial_pattern_of_number_expression((1, 5), "+3/13")
+
+    # 前後に数字ではない文字の場合
+    assert "13/1は"[0:4] == "13/1"
+    assert not is_parial_pattern_of_number_expression((0, 4), "13/1は")
+
+    assert "は3/13"[1:5] == "3/13"
+    assert not is_parial_pattern_of_number_expression((1, 5), "は3/13")


### PR DESCRIPTION
例

- `興行収入2億7.765万円を記録した`
- `1/50の縮小模型`
- `BCI-321+320/5MP`
- `Core i7-3770（3.90GHz）`